### PR TITLE
Use ember-intl before ember-i18n

### DIFF
--- a/addon/utils/message-provider.js
+++ b/addon/utils/message-provider.js
@@ -59,7 +59,15 @@ export default EmberObject.extend({
     if(Ember.i18n) {
       return Ember.i18n.t(`validation.${msg}`, replacements);
     }
-    let i18nService = get(this, 'container') ? get(this, 'container').lookup('service:i18n') : null;
+    const container = get(this, 'container');
+    // Check for ember-intl
+    let intlService = container ? container.lookup('service:intl') : null;
+    if (intlService) {
+      const translatedMessage = intlService.t(`validation.${msg}`, replacements);
+      if (!/Missing translation/.test(translatedMessage)) return translatedMessage;
+    }
+    // Check for ember-i18n
+    let i18nService = container ? container.lookup('service:i18n') : null;
     if (i18nService) {
       const translatedMessage = i18nService.t(`validation.${msg}`, replacements);
       if (!/Missing translation/.test(translatedMessage)) return translatedMessage;

--- a/addon/utils/message-provider.js
+++ b/addon/utils/message-provider.js
@@ -1,10 +1,9 @@
 import EmberObject, { get } from '@ember/object';
-import Ember from 'ember';
 
 export default EmberObject.extend({
   container: null,
   /**
-   * A dictionary of default messages - can be overriden by i18n
+   * A dictionary of default messages - can be overriden by intl
    * @param defaultMessages
    * @type {Object}
    */
@@ -32,7 +31,7 @@ export default EmberObject.extend({
    * Gets a validation message based on string returned uses _fetchMessage under the hood.
    *
    * @param {string|Object} if message is a string it is looked up in
-   *  defaultMessages/i18n. If it's an object it should contain keys message
+   *  defaultMessages/intl. If it's an object it should contain keys message
    *  and replacements. All occurences of replacements in message will be then
    *  replaced according to the replacements hash.
    * @returns {string}
@@ -48,28 +47,17 @@ export default EmberObject.extend({
   /**
    * This is a convenience function that fetches the message based on a key.
    *
-   * It checks ember-i18n first and if it doesn't exist it returns a default message.
-   * If ember-i18n is installed but does not define the key, it'll use the default one.
+   * It checks ember-intl first and if it doesn't exist it returns a default message.
+   * If ember-intl is installed but does not define the key, it'll use the default one.
    * @param {string} msg: a key
    * @param {Object} replacements: replacements for interpolation
    * @returns {string}
    * @private
    */
   _fetchMessage(msg, replacements = {}) {
-    if(Ember.i18n) {
-      return Ember.i18n.t(`validation.${msg}`, replacements);
-    }
-    const container = get(this, 'container');
-    // Check for ember-intl
-    let intlService = container ? container.lookup('service:intl') : null;
+    let intlService = get(this, 'container') ? get(this, 'container').lookup('service:intl') : null;
     if (intlService) {
       const translatedMessage = intlService.t(`validation.${msg}`, replacements);
-      if (!/Missing translation/.test(translatedMessage)) return translatedMessage;
-    }
-    // Check for ember-i18n
-    let i18nService = container ? container.lookup('service:i18n') : null;
-    if (i18nService) {
-      const translatedMessage = i18nService.t(`validation.${msg}`, replacements);
       if (!/Missing translation/.test(translatedMessage)) return translatedMessage;
     }
     return this._interpolateMessage(msg, replacements);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^2.0.0",
-    "ember-i18n": "5.0.1",
     "ember-load-initializers": "^1.0.0",
     "ember-qunit-assert-helpers": "^0.1.3",
     "ember-resolver": "^4.0.0",

--- a/tests/unit/utils/message-provider-test.js
+++ b/tests/unit/utils/message-provider-test.js
@@ -1,7 +1,6 @@
 import { set } from '@ember/object';
 import messageProvider from 'ember-legit-forms/utils/message-provider';
 import { module, test } from 'qunit';
-import Ember from 'ember';
 
 module('Unit | Utility | message provider');
 
@@ -16,45 +15,18 @@ test('it gets validation message', function(assert) {
   assert.equal(subject.getMessage('testKey'), 'test message');
 });
 
-test('it checks first i18n before getting local keys (globals)', function(assert) {
-  Ember.i18n = {
-    t() {
-      return 'test message from i18n globals';
-    }
-  };
-
-  assert.equal(subject.getMessage('testKey'), 'test message from i18n globals');
-});
-
-test('it checks first intl before i18n', function(assert) {
-  Ember.i18n = null;
+test('it checks first intl before getting local keys (globals)', function(assert) {
   set(subject, 'container', {
-    lookup(param) {
+    lookup() {
       return {
         t() {
-          return `test message from ${param}`;
+          return 'test message from intl service';
         }
       };
     }
   });
 
-  assert.equal(subject.getMessage('testKey'), 'test message from service:intl');
-});
-
-test('it checks i18n before getting local keys (globals)', function(assert) {
-  Ember.i18n = null;
-  set(subject, 'container', {
-    lookup(param) {
-      if (param === 'service:intl') { return; }
-      return {
-        t() {
-          return `test message from ${param}`;
-        }
-      };
-    }
-  });
-
-  assert.equal(subject.getMessage('testKey'), 'test message from service:i18n');
+  assert.equal(subject.getMessage('testKey'), 'test message from intl service');
 });
 
 test('it can interpolate messages with and w/o replacements', function(assert) {
@@ -69,21 +41,6 @@ test('it can interpolate messages with and w/o replacements', function(assert) {
 test('when intl installed but key not defined it uses default translation', function(assert) {
   set(subject, 'container', {
     lookup() {
-      return {
-        t(key) {
-          return `Missing translation: [${key}]`;
-        }
-      };
-    }
-  });
-  const message = subject._fetchMessage('testKey', {});
-  assert.equal(message, defaultMessages.testKey)
-});
-
-test('when i18n installed but key not defined it uses default translation', function(assert) {
-  set(subject, 'container', {
-    lookup(param) {
-      if (param === 'service:intl') { return; }
       return {
         t(key) {
           return `Missing translation: [${key}]`;

--- a/tests/unit/utils/message-provider-test.js
+++ b/tests/unit/utils/message-provider-test.js
@@ -26,19 +26,35 @@ test('it checks first i18n before getting local keys (globals)', function(assert
   assert.equal(subject.getMessage('testKey'), 'test message from i18n globals');
 });
 
-test('it checks first i18n before getting local keys (globals)', function(assert) {
+test('it checks first intl before i18n', function(assert) {
   Ember.i18n = null;
   set(subject, 'container', {
-    lookup() {
+    lookup(param) {
       return {
         t() {
-          return 'test message from i18n service';
+          return `test message from ${param}`;
         }
       };
     }
   });
 
-  assert.equal(subject.getMessage('testKey'), 'test message from i18n service');
+  assert.equal(subject.getMessage('testKey'), 'test message from service:intl');
+});
+
+test('it checks i18n before getting local keys (globals)', function(assert) {
+  Ember.i18n = null;
+  set(subject, 'container', {
+    lookup(param) {
+      if (param === 'service:intl') { return; }
+      return {
+        t() {
+          return `test message from ${param}`;
+        }
+      };
+    }
+  });
+
+  assert.equal(subject.getMessage('testKey'), 'test message from service:i18n');
 });
 
 test('it can interpolate messages with and w/o replacements', function(assert) {
@@ -50,9 +66,24 @@ test('it can interpolate messages with and w/o replacements', function(assert) {
   assert.equal(message, 'test message foo and bar');
 });
 
-test('when i18n installed but key not defined it uses default translation', function(assert) {
+test('when intl installed but key not defined it uses default translation', function(assert) {
   set(subject, 'container', {
     lookup() {
+      return {
+        t(key) {
+          return `Missing translation: [${key}]`;
+        }
+      };
+    }
+  });
+  const message = subject._fetchMessage('testKey', {});
+  assert.equal(message, defaultMessages.testKey)
+});
+
+test('when i18n installed but key not defined it uses default translation', function(assert) {
+  set(subject, 'container', {
+    lookup(param) {
+      if (param === 'service:intl') { return; }
       return {
         t(key) {
           return `Missing translation: [${key}]`;


### PR DESCRIPTION
Add support for `ember-intl` since the original repo is currently using `ember-i18n`.

Solves https://github.com/honeypotio/home/issues/149